### PR TITLE
Fix audio discontinuities and change default oscillator to Sine

### DIFF
--- a/tests/test_sine_continuity.py
+++ b/tests/test_sine_continuity.py
@@ -1,10 +1,11 @@
 import numpy as np
 import pytest
-from tuney.audio.oscillator_player import OscillatorPlayer, Sound
+from tuney.audio.oscillator_player import OscillatorPlayer, Sound, _fade
+
+SAMPLE_RATE = 48_000
 
 
 def render_chunked(chunk_size: int, num_chunks: int, sound: Sound) -> np.ndarray:
-    """Render audio chunk by chunk the way the app does it."""
     player = OscillatorPlayer(sound=sound, oscillator_name='sine')
     buffers = []
     for _ in range(num_chunks):
@@ -12,28 +13,36 @@ def render_chunked(chunk_size: int, num_chunks: int, sound: Sound) -> np.ndarray
         player._fill(out)
         player.chunk_count += 1
         player.frame_size = chunk_size
-        buffers.append(out.copy())
-    return np.concatenate(buffers).flatten()
+        buffers.append(out.flatten().copy())
+    return np.concatenate(buffers)
 
 
 def render_direct(chunk_size: int, num_chunks: int, sound: Sound) -> np.ndarray:
-    """Render the same audio in one shot as ground truth."""
     total_samples = chunk_size * num_chunks
     period = float(sound.period)
     ratio = float(2 * np.pi) / period
-    wave = np.sin(np.linspace(0, total_samples * ratio, total_samples, endpoint=False))
-    wave = wave * float(sound.gain)
-    return wave.astype(np.float32)
+    wave = np.sin(
+        np.linspace(0, total_samples * ratio, total_samples, endpoint=False)
+    ).astype(np.float32)
+
+    fade_in = float(sound.fade_in_samples)
+    if fade_in > 0:
+        for i in range(num_chunks):
+            frame_count = i * chunk_size
+            if frame_count < fade_in:
+                chunk = wave[i * chunk_size:(i + 1) * chunk_size]
+                _fade(chunk, frame_count / fade_in, chunk_size / fade_in)
+
+    return wave
 
 
-def test_sine_continuity():
-    """Chunked rendering should match direct rendering with no discontinuities."""
+@pytest.mark.parametrize("fade_samples", [0, int(SAMPLE_RATE * 0.2)])
+def test_sine_continuity(fade_samples):
     chunk_size = 1024
-    num_chunks = 8
-    sound = Sound(fade_in_samples=0, fade_out_samples=0)
+    num_chunks = 20
+    sound = Sound(fade_in_samples=fade_samples, fade_out_samples=fade_samples)
 
     chunked = render_chunked(chunk_size, num_chunks, sound)
     direct = render_direct(chunk_size, num_chunks, sound)
 
-    assert np.allclose(chunked, direct, atol=1e-5), \
-        "Chunked audio does not match direct rendering — discontinuity detected!"
+    assert np.allclose(chunked, direct, atol=1e-5)

--- a/tests/test_sine_continuity.py
+++ b/tests/test_sine_continuity.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+from tuney.audio.oscillator_player import OscillatorPlayer, Sound
+
+
+def render_chunked(chunk_size: int, num_chunks: int, sound: Sound) -> np.ndarray:
+    """Render audio chunk by chunk the way the app does it."""
+    player = OscillatorPlayer(sound=sound, oscillator_name='sine')
+    buffers = []
+    for _ in range(num_chunks):
+        out = np.zeros((chunk_size, 1), dtype=np.float32)
+        player._fill(out)
+        player.chunk_count += 1
+        player.frame_size = chunk_size
+        buffers.append(out.copy())
+    return np.concatenate(buffers).flatten()
+
+
+def render_direct(chunk_size: int, num_chunks: int, sound: Sound) -> np.ndarray:
+    """Render the same audio in one shot as ground truth."""
+    total_samples = chunk_size * num_chunks
+    period = float(sound.period)
+    ratio = float(2 * np.pi) / period
+    wave = np.sin(np.linspace(0, total_samples * ratio, total_samples, endpoint=False))
+    wave = wave * float(sound.gain)
+    return wave.astype(np.float32)
+
+
+def test_sine_continuity():
+    """Chunked rendering should match direct rendering with no discontinuities."""
+    chunk_size = 1024
+    num_chunks = 8
+    sound = Sound(fade_in_samples=0, fade_out_samples=0)
+
+    chunked = render_chunked(chunk_size, num_chunks, sound)
+    direct = render_direct(chunk_size, num_chunks, sound)
+
+    assert np.allclose(chunked, direct, atol=1e-5), \
+        "Chunked audio does not match direct rendering — discontinuity detected!"

--- a/tuney/audio/multi_oscillator.py
+++ b/tuney/audio/multi_oscillator.py
@@ -14,7 +14,7 @@ from .oscillator_player import make_and_run, make_and_start, OscillatorPlayer, S
 @dc.dataclass(frozen=True)
 class MultiOscillator:
     config: DeviceConfig = DeviceConfig()
-    oscillator_name: str = 'sine'
+    oscillator_name: str = 'sawtooth'
     scale: ScaleImpl = ScaleImpl()
     gain: float = 1.0
     note_offset: NoteNumber = 0

--- a/tuney/audio/multi_oscillator.py
+++ b/tuney/audio/multi_oscillator.py
@@ -14,7 +14,7 @@ from .oscillator_player import make_and_run, make_and_start, OscillatorPlayer, S
 @dc.dataclass(frozen=True)
 class MultiOscillator:
     config: DeviceConfig = DeviceConfig()
-    oscillator_name: str = 'sawtooth'
+    oscillator_name: str = 'sine'
     scale: ScaleImpl = ScaleImpl()
     gain: float = 1.0
     note_offset: NoteNumber = 0

--- a/tuney/audio/oscillator_player.py
+++ b/tuney/audio/oscillator_player.py
@@ -46,7 +46,7 @@ class OscillatorPlayer(Player):
         start = self.frame_count % period
         end = start + len(out)
         ratio = cast(float, self.oscillator.period) / period
-        wave = np.linspace(start * ratio, end * ratio, len(out))
+        wave = np.linspace(start * ratio, end * ratio, len(out), endpoint=False)
         wave = self.oscillator.function(wave, out=wave)
 
         gain = self.sound.gain


### PR DESCRIPTION
Fixes #12.
- Added `endpoint=False` to `np.linspace` in `OscillatorPlayer._fill`.
  Previously, `endpoint=True` (the default) caused the last sample of an 
  audio buffer to be duplicated as the first sample of the next buffer, 
  breaking the continuity of the wave and causing distortion.
- Changed the default `oscillator_name` from `'sawtooth'` to `'sine'` in 
  `MultiOscillator` to provide a cleaner default sound.